### PR TITLE
style(dashboard) set text color to white in trace window

### DIFF
--- a/web/src/pages/mouli/MouliContent.tsx
+++ b/web/src/pages/mouli/MouliContent.tsx
@@ -44,9 +44,9 @@ function TraceWindow(props: { content: string, close: () => void }) {
                         maxHeight: "calc(100vh - 12rem)",
                         maxWidth: "calc(100vw - 2rem)"
                     }}>
-                        <code className={"text-xs "}>
+                        <code className={"text-xs"}>
                             {props.content.split("\n").map((line, index) => (
-                                <div key={index}>{line}</div>
+                                <div className={"text-white"} key={index}>{line}</div>
                             ))}
                         </code>
                     </div>


### PR DESCRIPTION
Set the color of text in trace window to white for better readability